### PR TITLE
Fix responsive in small devices

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -20,7 +20,7 @@
     <main>
       {% block body %}{% endblock %}
       <figure class="-z-20">
-        <img src="{{ '/static/images/trisquel-down.png'|asseturl }}" alt="Trisquel" class="fixed right-0 -bottom-0 w-48 md:w-72 lg:bottom-0 lg:w-6/12 xl:w-4/12 xs:w-50 -z-20">
+        <img src="{{ '/static/images/trisquel-down.png'|asseturl }}" alt="Trisquel" class="fixed right-0 -bottom-0 w-1/5 min-[380px]:w-48 sm:w-40 md:w-72 lg:bottom-0 lg:w-6/12 xl:w-4/12 2xl:w-50 -z-20">
       </figure>
     </main>
   </body>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -20,7 +20,7 @@
     <main>
       {% block body %}{% endblock %}
       <figure class="-z-20">
-        <img src="{{ '/static/images/trisquel-down.png'|asseturl }}" alt="Trisquel" class="fixed right-0 -bottom-0 w-1/5 min-[380px]:w-48 sm:w-40 md:w-72 lg:bottom-0 lg:w-6/12 xl:w-4/12 2xl:w-50 -z-20">
+        <img src="{{ '/static/images/trisquel-down.png'|asseturl }}" alt="Trisquel" class="fixed right-0 -bottom-0 w-1/5 sm:w-40 md:w-72 lg:bottom-0 lg:w-6/12 xl:w-4/12 min-[380px]:w-48 -z-20 2xl:w-50">
       </figure>
     </main>
   </body>


### PR DESCRIPTION
👋🏽 With the current media breakpoints is still mounting the text in small devices width <380px (most of Android or Iphone SE)

This should fix it, please test it @seralot !

Before:
<img width="435" alt="Screenshot 2024-03-12 at 09 07 39" src="https://github.com/python-vigo/pycones24/assets/4062867/547e502e-c363-4df0-89e5-a238691bbad8">

After:
<img width="445" alt="Screenshot 2024-03-12 at 09 07 22" src="https://github.com/python-vigo/pycones24/assets/4062867/318efc3d-56de-4784-be76-d5bf05ac4393">

Thanks!