### PR TITLE
Añade script para evitar generar .po al lanzar lektor server

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Página web de la conferencia nacional de Python 2024 · Vigo · Galicia
 4. Arranca el servidor de desarrollo
 
 ```bash
-   lektor server
+   scripts/server
 ```
 
 Una vez que el servidor de desarrollo está en marcha, visita la url [127.0.0.1:5000](http://127.0.0.1:5000) o [127.0.0.1:5000/admin](http://127.0.0.1:5000/admin) para acceder a la interfaz del admin.

--- a/configs/i18n.ini
+++ b/configs/i18n.ini
@@ -3,3 +3,4 @@ translations = en,gl
 i18npath = i18n
 translate_paragraphwise = False
 url_prefix = https://2024.es.pycon.org/
+enable = True

--- a/scripts/server
+++ b/scripts/server
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+sed -i 's/^enable = True$/enable = False/' configs/i18n.ini
+lektor server
+sed -i 's/^enable = False$/enable = True/' configs/i18n.ini


### PR DESCRIPTION
He añadido este pequeño script para evitar generar las traducciones al lanzar `lektor server` y así sea más cómodo. ¿Cómo lo ves?

Cuando se quieran generar se usaría `lektor build`