### PR TITLE
Corrige diseño selector de idioma

### DIFF
--- a/templates/components/header.html
+++ b/templates/components/header.html
@@ -28,7 +28,7 @@
       <form
         class="mx-auto"
       >
-      <select class="text-white bg-transparent" onchange="location = this.options[this.selectedIndex].value;">
+      <select class="text-white bg-transparent *:active:bg-gray-50 *:active:text-black *:dark:active:bg-gray-700 *:dark:active:text-white text-lg" onchange="location = this.options[this.selectedIndex].value;">
         <option value="{{ '.'|url(alt='es') }}" {% if this.alt == 'es' %}selected{% endif %}>ES</option>
         <option value="{{ '.'|url(alt='en') }}" {% if this.alt == 'en' %}selected{% endif %}>EN</option>
         <option value="{{ '.'|url(alt='gl') }}" {% if this.alt == 'gl' %}selected{% endif %}>GAL</option>


### PR DESCRIPTION
Antes:

![imagen](https://github.com/python-vigo/pycones24/assets/56048614/bab4179e-424a-4511-85a3-0c9eaabb5fd4)


Ahora:

![imagen](https://github.com/python-vigo/pycones24/assets/56048614/4212e7e4-cad6-44f3-83c4-df179f40d7bd)
