### PR TITLE
Corrección de los colores del selector de idiomas

### DIFF
--- a/templates/components/header.html
+++ b/templates/components/header.html
@@ -37,7 +37,7 @@
       >
       <select
         aria-label="{{ _("Selecciona idioma") }}"
-        class="text-white bg-transparent *:active:bg-gray-50 *:active:text-black *:dark:active:bg-gray-700 *:dark:active:text-white text-lg"
+        class="text-white *:text-black bg-transparent *:dark:text-white *:dark:bg-gray-700 text-lg"
         onchange="location = this.options[this.selectedIndex].value;"
       >
         <option value="{{ '.'|url(alt='es') }}" {% if this.alt == 'es' %}selected{% endif %}>ES</option>


### PR DESCRIPTION
Arregla #103 cambiando los colores del selector de idiomas tanto para el modo oscuro como para el claro para que el texto se pueda leer correctamente.

En navegadores basados en Chromium (Tema claro y oscuro):
![SelectorChromeLight](https://github.com/python-vigo/pycones24/assets/97539106/e7b1518f-9d4b-48cc-bcae-2341e0e64e80) ![SelectorChromeDark](https://github.com/python-vigo/pycones24/assets/97539106/e0020fa8-0cd0-45ac-af6d-b278f0558b83)

En Firefox (Tema claro y oscuro):
![SelectorFirefoxLight](https://github.com/python-vigo/pycones24/assets/97539106/53de0500-984f-4247-9acf-72125df03b88) ![SelectorFirefoxDark](https://github.com/python-vigo/pycones24/assets/97539106/8618b1c1-3d16-424e-a1a9-0a2f30b4d70a)
