### PR TITLE
Cambiar el estilo del selector de idiomas

### DIFF
--- a/configs/i18n.ini
+++ b/configs/i18n.ini
@@ -3,4 +3,4 @@ translations = en,gl
 i18npath = i18n
 translate_paragraphwise = True
 url_prefix = https://2024.es.pycon.org/
-enable = False
+enable = True

--- a/configs/i18n.ini
+++ b/configs/i18n.ini
@@ -3,4 +3,4 @@ translations = en,gl
 i18npath = i18n
 translate_paragraphwise = True
 url_prefix = https://2024.es.pycon.org/
-enable = True
+enable = False

--- a/templates/components/header.html
+++ b/templates/components/header.html
@@ -45,20 +45,28 @@
     <a href="{{ '/menu'|url }}" data-hx-push-url="false" aria-label="{{ _("Abrir/cerrar menú") }}" class="xl:hidden">
       {{ load_icon('icons/ham-icon.html') }}
     </a>
-    <div>
-      <form
-        class="mx-auto"
-      >
-      <select
-        aria-label="{{ _("Selecciona idioma") }}"
-        class="text-white *:text-black bg-transparent *:dark:text-white *:dark:bg-gray-700 text-lg"
-        onchange="location = this.options[this.selectedIndex].value;"
-      >
-        <option value="{{ '.'|url(alt='es') }}" {% if this.alt == 'es' %}selected{% endif %}>ES</option>
-        <option value="{{ '.'|url(alt='en') }}" {% if this.alt == 'en' %}selected{% endif %}>EN</option>
-        <option value="{{ '.'|url(alt='gl') }}" {% if this.alt == 'gl' %}selected{% endif %}>GAL</option>
-      </select>
-      </form>
+    <div class="hidden relative xl:block group/information max-w-fit">
+      <button type="button" class="inline-flex gap-x-1 items-center text-lg font-bold leading-6 text-white peer uppercase" aria-expanded="false">
+        <span>
+          {% if this.alt == 'gl' %}
+            GAL 
+          {% else %}
+            {{this.alt}}
+          {% endif %}
+        </span>
+        {{ load_icon("icons/arrow-down.html") }}
+      </button>
+      <div class="absolute z-10 flex-col hidden w-screen *:px-6 *:py-1 -translate-x-1/2 bg-white rounded-lg left-1/2 max-w-max peer-focus:flex hover:flex border-[1.5px] border-secondary">
+          <a href="{{ '.'|url(alt='es') }}" class="text-lg font-semibold text-black hover:text-white hover:bg-secondary">
+            {{ _("ES") }}
+          </a>
+          <a href="{{ '.'|url(alt='en') }}" class="text-lg font-semibold text-black hover:text-white hover:bg-secondary">
+            {{ _("EN") }}
+          </a>
+          <a href="{{ '.'|url(alt='gl') }}" class="text-lg font-semibold text-black hover:text-white hover:bg-secondary">
+            {{ _("GAL") }}
+          </a>
+      </div>
     </div>
   </div>
 </nav>

--- a/templates/components/header.html
+++ b/templates/components/header.html
@@ -46,7 +46,7 @@
       {{ load_icon('icons/ham-icon.html') }}
     </a>
     <div class="hidden relative xl:block group/information max-w-fit">
-      <button type="button" class="inline-flex gap-x-1 items-center text-lg font-bold leading-6 text-white peer uppercase" aria-expanded="false">
+      <button type="button" class="inline-flex gap-x-1 items-center text-lg font-bold leading-6 text-white uppercase peer" aria-expanded="false">
         <span>
           {% if this.alt == 'gl' %}
             GAL 

--- a/templates/components/header.html
+++ b/templates/components/header.html
@@ -58,13 +58,13 @@
       </button>
       <div class="absolute z-10 flex-col hidden w-screen *:px-6 *:py-1 -translate-x-1/2 bg-white rounded-lg left-1/2 max-w-max peer-focus:flex hover:flex border-[1.5px] border-secondary">
           <a href="{{ '.'|url(alt='es') }}" class="text-lg font-semibold text-black hover:text-white hover:bg-secondary">
-            {{ _("ES") }}
+            ES
           </a>
           <a href="{{ '.'|url(alt='en') }}" class="text-lg font-semibold text-black hover:text-white hover:bg-secondary">
-            {{ _("EN") }}
+            EN
           </a>
           <a href="{{ '.'|url(alt='gl') }}" class="text-lg font-semibold text-black hover:text-white hover:bg-secondary">
-            {{ _("GAL") }}
+            GAL
           </a>
       </div>
     </div>


### PR DESCRIPTION
Para el issue #116 

![LanguageSelector1](https://github.com/python-vigo/pycones24/assets/97539106/9bb5d072-dfec-4b93-92c0-f30f2f910022)  ![LanguageSelector2](https://github.com/python-vigo/pycones24/assets/97539106/cb66ffc9-ff37-415c-8937-520c248b8a3c)

Cambia el estilo del selector de idiomas para hacerlo idéntico a Información. 
Además de eso también cambia la forma en la que funciona y pasa de usar `form` y `option`s como antes a usar `div`s y links, como lo hace Información. Esto es debido a que no se puede aplicar css complejo a elementos como `option`, y por eso mismo era imposible cambiar cosas como la anchura o los bordes.
Los problemas que supone esto son:
- El código es algo más grande y un poco más confuso
- Cada vez que se cambia el idioma, se recarga la página entera

Pero aún así era la forma que encontré de cambiarle el estilo al selector.