### PR TITLE
Cierra el Call for Papers

### DIFF
--- a/i18n/contents+en.po
+++ b/i18n/contents+en.po
@@ -463,6 +463,9 @@ msgstr "The conference will be mainly in Spanish, and depending on how many talk
 msgid "La convocatoria de propuestas (CFP) es hasta las 23:59 (UTC) del 9 de junio. Mejor no dejarlo para el último minuto."
 msgstr "The call for papers (CfP) closes at 23:59 UTC on June 9th. Do not leave it for the very last minute!"
 
+msgid "El periodo de la convocatoria de propuestas ha finalizado."
+msgstr "The call for papers has closed"
+
 msgid "La forma más habitual de viajar a Vigo es en coche. Las buenas conexiones de la ciudad facilitan el acceso a Vigo por autopista desde Madrid, Santiago, A Coruña y Oporto."
 msgstr "The most common way to get to Vigo is by car. Well connected, you can get to Vigo by highway from Madrid, Santiago, A Coruña and Porto."
 

--- a/i18n/contents+es.po
+++ b/i18n/contents+es.po
@@ -461,6 +461,9 @@ msgstr ""
 msgid "La convocatoria de propuestas (CFP) es hasta las 23:59 (UTC) del 9 de junio. Mejor no dejarlo para el último minuto."
 msgstr ""
 
+msgid "El periodo de la convocatoria de propuestas ha finalizado."
+msgstr ""
+
 msgid "La forma más habitual de viajar a Vigo es en coche. Las buenas conexiones de la ciudad facilitan el acceso a Vigo por autopista desde Madrid, Santiago, A Coruña y Oporto."
 msgstr ""
 

--- a/i18n/contents+gl.po
+++ b/i18n/contents+gl.po
@@ -463,6 +463,9 @@ msgstr "A conferencia será principalmente en castelán, e dependendo das charla
 msgid "La convocatoria de propuestas (CFP) es hasta las 23:59 (UTC) del 9 de junio. Mejor no dejarlo para el último minuto."
 msgstr "A convocatoria de propostas (CfP) acaba o 9 de Xuño ás 23:59 UTC. Mellor non deixalo para última hora."
 
+msgid "El periodo de la convocatoria de propuestas ha finalizado."
+msgstr "O período para a convocatoria de propostas xa acabou"
+
 msgid "La forma más habitual de viajar a Vigo es en coche. Las buenas conexiones de la ciudad facilitan el acceso a Vigo por autopista desde Madrid, Santiago, A Coruña y Oporto."
 msgstr "A forma máis habitual de viaxar a Vigo é en coche. As boas conexións da cidade facilitan o acceso a Vigo por autopista desde Madrid, Santiago, A Coruña e Porto."
 

--- a/templates/cfp.html
+++ b/templates/cfp.html
@@ -11,11 +11,8 @@
         {{ _("La convocatoria de propuestas (CFP) es hasta las 23:59 (UTC) del 9 de "
         "junio. Mejor no dejarlo para el último minuto.") }}
     </h3>
-    <div class="my-10">
-        <a href="https://pretalx.com/pycones-2024/" target="_blank"
-            class="p-3 px-6 text-xl font-bold text-white bg-primary hover:bg-secondary">
-            PyConES 2024, Vigo CFP
-        </a>
+    <div class="p-4 text-lg font-bold bg-red-100 border-l-4 text-secondary border-primary">
+        {{ _("El periodo de la convocatoria de propuestas ha finalizado.") }}
     </div>
     <article class="mb-5 text-xl">
         <p>


### PR DESCRIPTION
Elimina el link al petralx en el Call For Papers y añade un banner indicando que se ha cerrado.

![image](https://github.com/user-attachments/assets/a38ee52a-f1d3-4f12-bea0-8aac8823d827)

No quité ningún otro texto de la página (Como las recomendaciones para hacer la propuesta), aunque puedo borrar alguno en caso de que haga falta.

Soluciona el issue #123 