### PR TITLE
Traduce las ofertas de trabajo al castellano y al gallego

### DIFF
--- a/content/ofertas-trabajo/Fever-sbe/contents+es.lr
+++ b/content/ofertas-trabajo/Fever-sbe/contents+es.lr
@@ -2,13 +2,13 @@ company: Fever
 ---
 _template: job_offers/card_job.html
 ---
-city: Remote
+city: Remoto
 ---
 description:
 
-We are looking for a Senior Backend Engineer to join the backend team with outstanding software development talent proven by great work results/experience.
+Estamos buscando a un Ingeniero Senior de Backend para que se una a nuestro equipo de backend con un talento sobresaliente para el desarrollo de software demostrado por un gran trabajo y resultados/experiencia.
 
-If you're smart, have great energy and have interest in participating in the whole lifecycle of a feature - we are in sync.
+Si eres inteligente y tienes una gran energía e interés en participar en el desarrollo completo de una funcionalidad - entonces pensamos igual.
 ---
 link_job: https://careers.feverup.com/jobs/4085720101/senior-backend-engineer/
 ---
@@ -16,7 +16,7 @@ name_job: Senior Backend Engineer
 ---
 range_salary:
 
- (Including Base, Variable, and Stock Options) 67.500 - 90.000
+ (Incluyendo Base, Variable, y Opciones de Stock) 67.500 - 90.000
 ---
 skills:
 

--- a/content/ofertas-trabajo/Fever-sbe/contents+es.lr
+++ b/content/ofertas-trabajo/Fever-sbe/contents+es.lr
@@ -6,7 +6,7 @@ city: Remoto
 ---
 description:
 
-Estamos buscando a un Ingeniero Senior de Backend para que se una a nuestro equipo de backend con un talento sobresaliente para el desarrollo de software demostrado por un gran trabajo y resultados/experiencia.
+Estamos buscando a un Ingeniero Senior de Backend para que se una a nuestro equipo de backend, con un talento sobresaliente para el desarrollo de software demostrado por un gran trabajo y resultados/experiencia.
 
 Si eres inteligente y tienes una gran energía e interés en participar en el desarrollo completo de una funcionalidad - entonces pensamos igual.
 ---

--- a/content/ofertas-trabajo/Fever-sbe/contents+gl.lr
+++ b/content/ofertas-trabajo/Fever-sbe/contents+gl.lr
@@ -2,21 +2,21 @@ company: Fever
 ---
 _template: job_offers/card_job.html
 ---
-city: Remote
+city: Remoto
 ---
 description:
 
-We are looking for a Senior Backend Engineer to join the backend team with outstanding software development talent proven by great work results/experience.
+Estamos buscando a un Enxeñeiro Senior de Backend para que se una ao noso equipo de backend cun talento sobresaínte para o desenvolvemento de software demostrado por un gran traballo e resultados/experiencia.
 
-If you're smart, have great energy and have interest in participating in the whole lifecycle of a feature - we are in sync.
+Se eres intelixente e tes unha gran enerxía e interés en participar no desenvolvemento completo dunha funcionalidade - entón pensamos igual.
 ---
 link_job: https://careers.feverup.com/jobs/4085720101/senior-backend-engineer/
 ---
-name_job: Senior Backend Engineer
+name_job: Enxeñeiro Senior de Backend
 ---
 range_salary:
 
- (Including Base, Variable, and Stock Options) 67.500 - 90.000
+ (Incluíndo Base, Variable, e Opcións de Stock) 67.500 - 90.000
 ---
 skills:
 

--- a/content/ofertas-trabajo/Fever-sbe/contents+gl.lr
+++ b/content/ofertas-trabajo/Fever-sbe/contents+gl.lr
@@ -6,7 +6,7 @@ city: Remoto
 ---
 description:
 
-Estamos buscando a un Enxeñeiro Senior de Backend para que se una ao noso equipo de backend cun talento sobresaínte para o desenvolvemento de software demostrado por un gran traballo e resultados/experiencia.
+Estamos buscando a un Enxeñeiro Senior de Backend para que se una ao noso equipo de backend, cun talento sobresaínte para o desenvolvemento de software demostrado por un gran traballo e resultados/experiencia.
 
 Se eres intelixente e tes unha gran enerxía e interés en participar no desenvolvemento completo dunha funcionalidade - entón pensamos igual.
 ---

--- a/content/ofertas-trabajo/Skydance-Animation-Madrid-ltd/contents+es.lr
+++ b/content/ofertas-trabajo/Skydance-Animation-Madrid-ltd/contents+es.lr
@@ -2,9 +2,9 @@ company: Skydance Animation Madrid
 ---
 _template: job_offers/card_job.html
 ---
-city: Madrid - Hybrid
+city: Madrid - Híbrido
 ---
-description: As a Lead Technical Director, you will guide a development and support team in building innovative tools for the production teams to efficiently create animated films at Skydance.
+description: Como Lead Technical Director, guiarás un equipo de desarrollo y soporte en la construcción de herramientas innovadoras para que los equipos de producción puedan crear películas animadas de forma eficiente en Skydance.
 ---
 link_job: https://skydance.com/job/?id=28742332-2d1d-4198-a162-0a84de9b77dc
 ---

--- a/content/ofertas-trabajo/Skydance-Animation-Madrid-ltd/contents+gl.lr
+++ b/content/ofertas-trabajo/Skydance-Animation-Madrid-ltd/contents+gl.lr
@@ -2,9 +2,9 @@ company: Skydance Animation Madrid
 ---
 _template: job_offers/card_job.html
 ---
-city: Madrid - Hybrid
+city: Madrid - Híbrido
 ---
-description: As a Lead Technical Director, you will guide a development and support team in building innovative tools for the production teams to efficiently create animated films at Skydance.
+description: Como Lead Technical Director, guiarás un equipo de desenvolvemento e soporte na construcción de ferramentas innovadoras para que os equipos de produción poidan crear películas animadas de forma eficiente en Skydance.
 ---
 link_job: https://skydance.com/job/?id=28742332-2d1d-4198-a162-0a84de9b77dc
 ---

--- a/content/ofertas-trabajo/Skydance-Animation-Madrid-spd/contents+es.lr
+++ b/content/ofertas-trabajo/Skydance-Animation-Madrid-spd/contents+es.lr
@@ -2,9 +2,9 @@ company: Skydance Animation Madrid
 ---
 _template: job_offers/card_job.html
 ---
-city: Madrid - Hybrid
+city: Madrid - Híbrido
 ---
-description: As a Senior Pipeline Engineer, you will define, develop, test, analyze, and maintain software applications and libraries for the global feature animation pipeline by employing industry best practices.
+description: Como Senior Pipeline Engineer, definirás, desarrollarás, probarás, analizarás y mantendrás aplicaciones y librerías de software para la pipeline de funcionalidad global de la animación, empleando las mejores prácticas de la industria.
 ---
 link_job: https://skydance.com
 ---

--- a/content/ofertas-trabajo/Skydance-Animation-Madrid-spd/contents+gl.lr
+++ b/content/ofertas-trabajo/Skydance-Animation-Madrid-spd/contents+gl.lr
@@ -2,9 +2,9 @@ company: Skydance Animation Madrid
 ---
 _template: job_offers/card_job.html
 ---
-city: Madrid - Hybrid
+city: Madrid - Híbrido
 ---
-description: As a Senior Pipeline Engineer, you will define, develop, test, analyze, and maintain software applications and libraries for the global feature animation pipeline by employing industry best practices.
+description: Como Senior Pipeline Engineer, definirás, desenvolverás, probarás, analizarás e manterás aplicacións e librerías de software para a pipeline de funcionalidade global da animación, empleando as mellores prácticas da industria.
 ---
 link_job: https://skydance.com
 ---

--- a/content/ofertas-trabajo/Skydance-Animation-Madrid-std/contents+es.lr
+++ b/content/ofertas-trabajo/Skydance-Animation-Madrid-std/contents+es.lr
@@ -2,9 +2,9 @@ company: Skydance Animation Madrid
 ---
 _discoverable: yes
 ---
-city: Madrid - Hybrid
+city: Madrid - Híbrido
 ---
-description: As a Senior TD, you will develop and support innovative tools for our production teams to efficiently create animated films at Skydance.
+description: Como Senior Technical Director, desarrollarás y mantendrás herramientas innovadoras para que nuestros equipos de producción puedan crear películas animadas de forma eficiente en Skydance.
 ---
 link_job: https://skydance.com/job/?id=eaff4794-28cc-4dd8-a767-b12fb84e5e6e
 ---

--- a/content/ofertas-trabajo/Skydance-Animation-Madrid-std/contents+gl.lr
+++ b/content/ofertas-trabajo/Skydance-Animation-Madrid-std/contents+gl.lr
@@ -2,9 +2,9 @@ company: Skydance Animation Madrid
 ---
 _discoverable: yes
 ---
-city: Madrid - Hybrid
+city: Madrid - Híbrido
 ---
-description: As a Senior TD, you will develop and support innovative tools for our production teams to efficiently create animated films at Skydance.
+description: Como Senior Technical Director, desenvolverás e manterás ferramentas innovadoras para que os nosos equipos de produción poidan crear películas animadas de forma eficiente en Skydance.
 ---
 link_job: https://skydance.com/job/?id=eaff4794-28cc-4dd8-a767-b12fb84e5e6e
 ---

--- a/content/ofertas-trabajo/fever-el/contents+es.lr
+++ b/content/ofertas-trabajo/fever-el/contents+es.lr
@@ -2,15 +2,15 @@ company: Fever
 ---
 _template: job_offers/card_job.html
 ---
-city: Remote
+city: Remoto
 ---
-description: Are you an experienced Senior Software Engineer ready to take the next step in your career? We are looking for a talented individual to transition into a management role, leading our dynamic engineering team. This is an exciting opportunity to shape the future of our tech space.
+description: ¿Eres un Desarrollador de Software Senior preparado para dar tu siguiente salto en tu carrera? Estamos buscando una persona talentosa para que asuma un rol de gestión, liderando nuestro dinámico equipo de ingeniería. Esta es una oportunidad emocionante para definir el futuro de nuestro espacio tecnológico.
 ---
 link_job: https://careers.feverup.com/jobs/4090971101/engineering-lead/
 ---
 name_job: Engineering Lead
 ---
-range_salary: Check Offer
+range_salary: Comprobar en la Oferta
 ---
 skills: N/A
 ---

--- a/content/ofertas-trabajo/fever-el/contents+gl.lr
+++ b/content/ofertas-trabajo/fever-el/contents+gl.lr
@@ -2,15 +2,15 @@ company: Fever
 ---
 _template: job_offers/card_job.html
 ---
-city: Remote
+city: Remoto
 ---
-description: Are you an experienced Senior Software Engineer ready to take the next step in your career? We are looking for a talented individual to transition into a management role, leading our dynamic engineering team. This is an exciting opportunity to shape the future of our tech space.
+description: Eres un Desenvolvedor de Software Senior preparado para dar o teu seguinte salto na túa carreira profesional? Estamos buscando unha persoa talentosa que poida asumir un rol de xestión, liderando o noso dinámico equipo de enxeñería. Esta é unha oportunidade emocionante para definir o futuro do noso espazo tecnolóxico.
 ---
 link_job: https://careers.feverup.com/jobs/4090971101/engineering-lead/
 ---
 name_job: Engineering Lead
 ---
-range_salary: Check Offer
+range_salary: Comprobar en la Oferta
 ---
 skills: N/A
 ---

--- a/content/ofertas-trabajo/fever-sfe/contents+en.lr
+++ b/content/ofertas-trabajo/fever-sfe/contents+en.lr
@@ -6,7 +6,7 @@ city: Remote
 ---
 description:
 
-We are looking for a Senior Frontend Engineer to join the backend team with outstanding software development talent proven by great work results/experience.
+We are looking for a Senior Frontend Engineer to join the frontend team with outstanding software development talent proven by great work results/experience.
 If you're smart, have great energy and have interest in participating in the whole lifecycle of a feature - we are in sync.
 ---
 link_job: https://careers.feverup.com/jobs/4089984101/senior-frontend-engineer/

--- a/content/ofertas-trabajo/fever-sfe/contents+es.lr
+++ b/content/ofertas-trabajo/fever-sfe/contents+es.lr
@@ -2,18 +2,18 @@ company: Fever
 ---
 _template: job_offers/card_job.html
 ---
-city: Remote
+city: Remoto
 ---
 description:
 
-We are looking for a Senior Frontend Engineer to join the backend team with outstanding software development talent proven by great work results/experience.
-If you're smart, have great energy and have interest in participating in the whole lifecycle of a feature - we are in sync.
+Estamos buscando a un Ingeniero Senior de Frontend para que se una a nuestro equipo de frontend con un talento sobresaliente para el desarrollo de software demostrado por un gran trabajo y resultados/experiencia.
+Si eres inteligente y tienes una gran energía e interés en participar en el desarrollo completo de una funcionalidad - entonces pensamos igual.
 ---
 link_job: https://careers.feverup.com/jobs/4089984101/senior-frontend-engineer/
 ---
 name_job: Senior Frontend Engineer
 ---
-range_salary: (Including Base, Bonus and Stock Options) 67.500 - 90.000
+range_salary: (Incluyendo Base, Bonus y Opciones de Stock) 67.500 - 90.000
 ---
 skills:
 

--- a/content/ofertas-trabajo/fever-sfe/contents+es.lr
+++ b/content/ofertas-trabajo/fever-sfe/contents+es.lr
@@ -6,7 +6,7 @@ city: Remoto
 ---
 description:
 
-Estamos buscando a un Ingeniero Senior de Frontend para que se una a nuestro equipo de frontend con un talento sobresaliente para el desarrollo de software demostrado por un gran trabajo y resultados/experiencia.
+Estamos buscando a un Ingeniero Senior de Frontend para que se una a nuestro equipo de frontend, con un talento sobresaliente para el desarrollo de software demostrado por un gran trabajo y resultados/experiencia.
 Si eres inteligente y tienes una gran energía e interés en participar en el desarrollo completo de una funcionalidad - entonces pensamos igual.
 ---
 link_job: https://careers.feverup.com/jobs/4089984101/senior-frontend-engineer/

--- a/content/ofertas-trabajo/fever-sfe/contents+gl.lr
+++ b/content/ofertas-trabajo/fever-sfe/contents+gl.lr
@@ -6,7 +6,7 @@ city: Remoto
 ---
 description:
 
-Estamos buscando a un Enxeñeiro Senior de Frontend para que se una ao noso equipo de frontend cun talento sobresaínte para o desenvolvemento de software demostrado por un gran traballo e resultados/experiencia.
+Estamos buscando a un Enxeñeiro Senior de Frontend para que se una ao noso equipo de frontend, cun talento sobresaínte para o desenvolvemento de software demostrado por un gran traballo e resultados/experiencia.
 Se eres intelixente e tes unha gran enerxía e interés en participar no desenvolvemento completo dunha funcionalidade - entón pensamos igual.
 ---
 link_job: https://careers.feverup.com/jobs/4089984101/senior-frontend-engineer/

--- a/content/ofertas-trabajo/fever-sfe/contents+gl.lr
+++ b/content/ofertas-trabajo/fever-sfe/contents+gl.lr
@@ -2,18 +2,18 @@ company: Fever
 ---
 _template: job_offers/card_job.html
 ---
-city: Remote
+city: Remoto
 ---
 description:
 
-We are looking for a Senior Frontend Engineer to join the backend team with outstanding software development talent proven by great work results/experience.
-If you're smart, have great energy and have interest in participating in the whole lifecycle of a feature - we are in sync.
+Estamos buscando a un Enxeñeiro Senior de Frontend para que se una ao noso equipo de frontend cun talento sobresaínte para o desenvolvemento de software demostrado por un gran traballo e resultados/experiencia.
+Se eres intelixente e tes unha gran enerxía e interés en participar no desenvolvemento completo dunha funcionalidade - entón pensamos igual.
 ---
 link_job: https://careers.feverup.com/jobs/4089984101/senior-frontend-engineer/
 ---
 name_job: Senior Frontend Engineer
 ---
-range_salary: (Including Base, Bonus and Stock Options) 67.500 - 90.000
+range_salary: (Incluíndo Base, Bonus e Opcións de Stock) 67.500 - 90.000
 ---
 skills:
 

--- a/content/ofertas-trabajo/fever-tl/contents+es.lr
+++ b/content/ofertas-trabajo/fever-tl/contents+es.lr
@@ -2,22 +2,22 @@ company: Fever
 ---
 _template: job_offers/card_job.html
 ---
-city: Remote
+city: Remoto
 ---
-description: We are looking for a Tech Lead to join Fever with outstanding software development talent proven by great work results/experience. Somebody that cares about code quality and not just get things done, but get things done right - to lead engineering developments for product teams.
+description: Estamos buscando a un Tech Lead para que se una a Fever con un talento sobresaliente para el desarrollo de software, demostrado por un gran trabajo y resultados/experiencia. Alguien al que le importe la calidad del código y no solo hacer que las cosas funcionen, pero que haga las cosas bien - para liderar los desarrollos para los equipos de producto.
 ---
 link_job: https://careers.feverup.com/jobs/4090030101/tech-lead/
 ---
 name_job: Tech Lead
 ---
-range_salary: (Including Base, Bonus, and Stock Options) 80.000 - 108.000
+range_salary: (Incluyendo Base, Bonus, y Opciones de Stock) 80.000 - 108.000
 ---
 skills:
 
-Good practices
+buenas prácticas
 testing
-design patterns
+patrones de diseño
 CI/CD
-distributed systems
+sistemas distribuidos
 ---
 contact_email: pablo.arribas@feverup.com

--- a/content/ofertas-trabajo/fever-tl/contents+es.lr
+++ b/content/ofertas-trabajo/fever-tl/contents+es.lr
@@ -4,7 +4,7 @@ _template: job_offers/card_job.html
 ---
 city: Remoto
 ---
-description: Estamos buscando a un Tech Lead para que se una a Fever con un talento sobresaliente para el desarrollo de software, demostrado por un gran trabajo y resultados/experiencia. Alguien al que le importe la calidad del código y no solo hacer que las cosas funcionen, pero que haga las cosas bien - para liderar los desarrollos para los equipos de producto.
+description: Estamos buscando a un Tech Lead para que se una a Fever, con un talento sobresaliente para el desarrollo de software, demostrado por un gran trabajo y resultados/experiencia. Alguien al que le importe la calidad del código y no solo hacer que las cosas funcionen, pero que haga las cosas bien - para liderar los desarrollos para los equipos de producto.
 ---
 link_job: https://careers.feverup.com/jobs/4090030101/tech-lead/
 ---

--- a/content/ofertas-trabajo/fever-tl/contents+gl.lr
+++ b/content/ofertas-trabajo/fever-tl/contents+gl.lr
@@ -4,7 +4,7 @@ _template: job_offers/card_job.html
 ---
 city: Remoto
 ---
-description: Estamos buscando un Tech Lead para que poida unierse a Fever cun talento sobresaínte para o desenvolvemento de software, demostrado por un gran traballo e resultados/experiencia. Alguén ao que lle importe a calidade do código e non so facer que as cousas funcionen, pero que faga as cousas ben - para liderar os desenvolvementos para os equipos de producto.
+description: Estamos buscando un Tech Lead para que poida unierse a Fever, cun talento sobresaínte para o desenvolvemento de software, demostrado por un gran traballo e resultados/experiencia. Alguén ao que lle importe a calidade do código e non so facer que as cousas funcionen, pero que faga as cousas ben - para liderar os desenvolvementos para os equipos de producto.
 ---
 link_job: https://careers.feverup.com/jobs/4090030101/tech-lead/
 ---

--- a/content/ofertas-trabajo/fever-tl/contents+gl.lr
+++ b/content/ofertas-trabajo/fever-tl/contents+gl.lr
@@ -4,7 +4,6 @@ _template: job_offers/card_job.html
 ---
 city: Remoto
 ---
-description: Estamos buscando a un Tech Lead para que se una a Fever con un talento sobresaliente para el desarrollo de software, demostrado por un gran trabajo y resultados/experiencia. Alguien al que le importe la calidad del código y no solo hacer que las cosas funcionen, pero que haga las cosas bien - para liderar los desarrollos para los equipos de producto.
 description: Estamos buscando un Tech Lead para que poida unierse a Fever cun talento sobresaínte para o desenvolvemento de software, demostrado por un gran traballo e resultados/experiencia. Alguén ao que lle importe a calidade do código e non so facer que as cousas funcionen, pero que faga as cousas ben - para liderar os desenvolvementos para os equipos de producto.
 ---
 link_job: https://careers.feverup.com/jobs/4090030101/tech-lead/

--- a/content/ofertas-trabajo/fever-tl/contents+gl.lr
+++ b/content/ofertas-trabajo/fever-tl/contents+gl.lr
@@ -2,22 +2,23 @@ company: Fever
 ---
 _template: job_offers/card_job.html
 ---
-city: Remote
+city: Remoto
 ---
-description: We are looking for a Tech Lead to join Fever with outstanding software development talent proven by great work results/experience. Somebody that cares about code quality and not just get things done, but get things done right - to lead engineering developments for product teams.
+description: Estamos buscando a un Tech Lead para que se una a Fever con un talento sobresaliente para el desarrollo de software, demostrado por un gran trabajo y resultados/experiencia. Alguien al que le importe la calidad del código y no solo hacer que las cosas funcionen, pero que haga las cosas bien - para liderar los desarrollos para los equipos de producto.
+description: Estamos buscando un Tech Lead para que poida unierse a Fever cun talento sobresaínte para o desenvolvemento de software, demostrado por un gran traballo e resultados/experiencia. Alguén ao que lle importe a calidade do código e non so facer que as cousas funcionen, pero que faga as cousas ben - para liderar os desenvolvementos para os equipos de producto.
 ---
 link_job: https://careers.feverup.com/jobs/4090030101/tech-lead/
 ---
 name_job: Tech Lead
 ---
-range_salary: (Including Base, Bonus, and Stock Options) 80.000 - 108.000
+range_salary: (Incluíndo Base, Bonus, e Opcións de Stock) 80.000 - 108.000
 ---
 skills:
 
-Good practices
+Boas prácticas
 testing
-design patterns
+patróns de deseño
 CI/CD
-distributed systems
+sistemas distribuídos
 ---
 contact_email: pablo.arribas@feverup.com

--- a/content/ofertas-trabajo/travelperk-se/contents+es.lr
+++ b/content/ofertas-trabajo/travelperk-se/contents+es.lr
@@ -6,7 +6,7 @@ description:
 
 No estamos buscando a expertos en stacks. Estamos buscando a gente inteligente que pueda traer las mejores herramientas y metodologías para conseguir hacer el trabajo.
 
-Trabajarás en una base del día a día con nuestro equipo de producto para diseñar, crear la arquitectura, e implementar nuestro producto. TravelPerk es una plataforma de siguiente generación para hacer más ameno el proceso de alquilar y organizar viajes de negocios.
+Trabajarás en el día a día con nuestro equipo de producto para diseñar, crear la arquitectura, e implementar nuestro producto. TravelPerk es una plataforma de siguiente generación para hacer más ameno el proceso de alquilar y organizar viajes de negocios.
 ---
 link_job: https://www.travelperk.com/job-application/?gh_jid=4770555&gh_src=4276577e1us
 ---

--- a/content/ofertas-trabajo/travelperk-se/contents+es.lr
+++ b/content/ofertas-trabajo/travelperk-se/contents+es.lr
@@ -1,12 +1,12 @@
 company: TravelPerk
 ---
-city: Barcelona - Hybrid
+city: Barcelona - Híbrido
 ---
 description:
 
-We’re not looking for stack experts. We’re looking for smart people who can bring in the best tools and processes to get the job done. 
+No estamos buscando a expertos en stacks. Estamos buscando a gente inteligente que pueda traer las mejores herramientas y metodologías para conseguir hacer el trabajo.
 
-You will work on a day-to-day basis with our product team to design, architect and implement our product. TravelPerk is a next-generation platform to take the pain out of booking and managing business travel. 
+Trabajarás en una base del día a día con nuestro equipo de producto para diseñar, crear la arquitectura, e implementar nuestro producto. TravelPerk es una plataforma de siguiente generación para hacer más ameno el proceso de alquilar y organizar viajes de negocios.
 ---
 link_job: https://www.travelperk.com/job-application/?gh_jid=4770555&gh_src=4276577e1us
 ---

--- a/content/ofertas-trabajo/travelperk-se/contents+gl.lr
+++ b/content/ofertas-trabajo/travelperk-se/contents+gl.lr
@@ -1,12 +1,12 @@
 company: TravelPerk
 ---
-city: Barcelona - Hybrid
+city: Barcelona - Híbrido
 ---
 description:
 
-We’re not looking for stack experts. We’re looking for smart people who can bring in the best tools and processes to get the job done. 
+Non estamos buscando a expertos en stacks. Estamos buscando a persoas intelixentes que poidan traer as mellores ferramentas e metodoloxías para conseguir facer o traballo.
 
-You will work on a day-to-day basis with our product team to design, architect and implement our product. TravelPerk is a next-generation platform to take the pain out of booking and managing business travel. 
+Traballarás nunha base do día a día co noso equipo de producto para deseñar, crear a arquitectura, e implementar o noso producto. TravelPerk é unha plataforma da seguinte xeración para facer máis ameno o proceso de alquilar e organizar viaxes de negocios.
 ---
 link_job: https://www.travelperk.com/job-application/?gh_jid=4770555&gh_src=4276577e1us
 ---

--- a/content/ofertas-trabajo/travelperk-se/contents+gl.lr
+++ b/content/ofertas-trabajo/travelperk-se/contents+gl.lr
@@ -6,7 +6,7 @@ description:
 
 Non estamos buscando a expertos en stacks. Estamos buscando a persoas intelixentes que poidan traer as mellores ferramentas e metodoloxías para conseguir facer o traballo.
 
-Traballarás nunha base do día a día co noso equipo de producto para deseñar, crear a arquitectura, e implementar o noso producto. TravelPerk é unha plataforma da seguinte xeración para facer máis ameno o proceso de alquilar e organizar viaxes de negocios.
+Traballarás no día a día co noso equipo de producto para deseñar, crear a arquitectura, e implementar o noso producto. TravelPerk é unha plataforma da seguinte xeración para facer máis ameno o proceso de alquilar e organizar viaxes de negocios.
 ---
 link_job: https://www.travelperk.com/job-application/?gh_jid=4770555&gh_src=4276577e1us
 ---

--- a/content/ofertas-trabajo/travelperk/contents+es.lr
+++ b/content/ofertas-trabajo/travelperk/contents+es.lr
@@ -1,12 +1,12 @@
 company: TravelPerk
 ---
-city: Barcelona - Hybrid
+city: Barcelona - Híbrido
 ---
 description:
 
-We’re not looking for stack experts. We’re looking for smart people who can bring in the best tools and processes to get the job done. 
+No estamos buscando a expertos en stacks. Estamos buscando a gente inteligente que pueda traer las mejores herramientas y metodologías para conseguir hacer el trabajo.
 
-You will work on a day-to-day basis with our product team to design, architect and implement our product. TravelPerk is a next-generation platform to take the pain out of booking and managing business travel. 
+Trabajarás en una base del día a día con nuestro equipo de producto para diseñar, crear la arquitectura, e implementar nuestro producto. TravelPerk es una plataforma de siguiente generación para hacer más ameno el proceso de alquilar y organizar viajes de negocios.
 
 ---
 link_job: https://www.travelperk.com/job-application/?gh_jid=4770538&gh_src=7538dea51us

--- a/content/ofertas-trabajo/travelperk/contents+es.lr
+++ b/content/ofertas-trabajo/travelperk/contents+es.lr
@@ -6,7 +6,7 @@ description:
 
 No estamos buscando a expertos en stacks. Estamos buscando a gente inteligente que pueda traer las mejores herramientas y metodologías para conseguir hacer el trabajo.
 
-Trabajarás en una base del día a día con nuestro equipo de producto para diseñar, crear la arquitectura, e implementar nuestro producto. TravelPerk es una plataforma de siguiente generación para hacer más ameno el proceso de alquilar y organizar viajes de negocios.
+Trabajarás en el día a día con nuestro equipo de producto para diseñar, crear la arquitectura, e implementar nuestro producto. TravelPerk es una plataforma de siguiente generación para hacer más ameno el proceso de alquilar y organizar viajes de negocios.
 
 ---
 link_job: https://www.travelperk.com/job-application/?gh_jid=4770538&gh_src=7538dea51us

--- a/content/ofertas-trabajo/travelperk/contents+gl.lr
+++ b/content/ofertas-trabajo/travelperk/contents+gl.lr
@@ -1,12 +1,12 @@
 company: TravelPerk
 ---
-city: Barcelona - Hybrid
+city: Barcelona - Híbrido
 ---
 description:
 
-We’re not looking for stack experts. We’re looking for smart people who can bring in the best tools and processes to get the job done. 
+Non estamos buscando a expertos en stacks. Estamos buscando a persoas intelixentes que poidan traer as mellores ferramentas e metodoloxías para conseguir facer o traballo.
 
-You will work on a day-to-day basis with our product team to design, architect and implement our product. TravelPerk is a next-generation platform to take the pain out of booking and managing business travel. 
+Traballarás nunha base do día a día co noso equipo de producto para deseñar, crear a arquitectura, e implementar o noso producto. TravelPerk é unha plataforma da seguinte xeración para facer máis ameno o proceso de alquilar e organizar viaxes de negocios.
 
 ---
 link_job: https://www.travelperk.com/job-application/?gh_jid=4770538&gh_src=7538dea51us

--- a/content/ofertas-trabajo/travelperk/contents+gl.lr
+++ b/content/ofertas-trabajo/travelperk/contents+gl.lr
@@ -6,7 +6,7 @@ description:
 
 Non estamos buscando a expertos en stacks. Estamos buscando a persoas intelixentes que poidan traer as mellores ferramentas e metodoloxías para conseguir facer o traballo.
 
-Traballarás nunha base do día a día co noso equipo de producto para deseñar, crear a arquitectura, e implementar o noso producto. TravelPerk é unha plataforma da seguinte xeración para facer máis ameno o proceso de alquilar e organizar viaxes de negocios.
+Traballarás no día a día co noso equipo de producto para deseñar, crear a arquitectura, e implementar o noso producto. TravelPerk é unha plataforma da seguinte xeración para facer máis ameno o proceso de alquilar e organizar viaxes de negocios.
 
 ---
 link_job: https://www.travelperk.com/job-application/?gh_jid=4770538&gh_src=7538dea51us


### PR DESCRIPTION
Traduce todas las ofertas de trabajo al castellano y al gallego.

El único problema que he encontrado es que el texto de las de TravelPerk se corta por ser demasiado largo, si hace falta puedo intentar acortar la descripción o aumentar el límite de caracteres de la oferta.
![image](https://github.com/user-attachments/assets/881c375b-c785-47a9-96b8-8e13c4663685)
